### PR TITLE
Add POS order synchronization module

### DIFF
--- a/addons/pos_order_sync/README.rst
+++ b/addons/pos_order_sync/README.rst
@@ -1,0 +1,7 @@
+POS Order Sync
+==============
+
+This module provides a minimal interface to copy Point of Sale orders from one
+Odoo 18 instance to another using JSON-RPC calls. Users can configure source and
+destination instances, select a date range and trigger synchronization. A log is
+kept for successful and failed orders.

--- a/addons/pos_order_sync/__init__.py
+++ b/addons/pos_order_sync/__init__.py
@@ -1,0 +1,2 @@
+from . import models
+from . import wizards

--- a/addons/pos_order_sync/__manifest__.py
+++ b/addons/pos_order_sync/__manifest__.py
@@ -1,0 +1,15 @@
+{
+    'name': 'POS Order Sync',
+    'version': '1.0',
+    'summary': 'Copy POS orders between Odoo instances',
+    'depends': ['point_of_sale'],
+    'data': [
+        'security/ir.model.access.csv',
+        'views/pos_sync_instance_views.xml',
+        'views/pos_sync_log_views.xml',
+        'wizards/pos_sync_wizard_views.xml',
+        'views/menu.xml',
+    ],
+    'installable': True,
+    'license': 'LGPL-3',
+}

--- a/addons/pos_order_sync/models/__init__.py
+++ b/addons/pos_order_sync/models/__init__.py
@@ -1,0 +1,2 @@
+from . import pos_sync_instance
+from . import pos_sync_log

--- a/addons/pos_order_sync/models/pos_sync_instance.py
+++ b/addons/pos_order_sync/models/pos_sync_instance.py
@@ -1,0 +1,12 @@
+from odoo import models, fields
+
+
+class PosSyncInstance(models.Model):
+    _name = 'pos.sync.instance'
+    _description = 'POS Sync Instance'
+
+    name = fields.Char(required=True)
+    url = fields.Char(required=True)
+    db = fields.Char(string='Database', required=True)
+    username = fields.Char(required=True)
+    password = fields.Char(required=True)

--- a/addons/pos_order_sync/models/pos_sync_log.py
+++ b/addons/pos_order_sync/models/pos_sync_log.py
@@ -1,0 +1,14 @@
+from odoo import models, fields
+
+
+class PosSyncLog(models.Model):
+    _name = 'pos.sync.log'
+    _description = 'POS Order Sync Log'
+    _order = 'create_date desc'
+
+    source_order = fields.Char(string='Source Order')
+    status = fields.Selection([
+        ('success', 'Success'),
+        ('error', 'Error')
+    ], default='success')
+    message = fields.Text()

--- a/addons/pos_order_sync/security/ir.model.access.csv
+++ b/addons/pos_order_sync/security/ir.model.access.csv
@@ -1,0 +1,3 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_pos_sync_instance,pos.sync.instance,model_pos_sync_instance,base.group_user,1,1,1,1
+access_pos_sync_log,pos.sync.log,model_pos_sync_log,base.group_user,1,0,0,0

--- a/addons/pos_order_sync/views/menu.xml
+++ b/addons/pos_order_sync/views/menu.xml
@@ -1,0 +1,9 @@
+<odoo>
+    <menuitem id="menu_pos_sync_root" name="POS Sync" parent="point_of_sale.menu_point_root" sequence="50" groups="base.group_user"/>
+
+    <menuitem id="menu_pos_sync_instance" name="Instances" parent="menu_pos_sync_root" action="action_pos_sync_instance" sequence="10" groups="base.group_user"/>
+
+    <menuitem id="menu_pos_sync_wizard" name="Sync Orders" parent="menu_pos_sync_root" action="action_pos_sync_wizard" sequence="20" groups="base.group_user"/>
+
+    <menuitem id="menu_pos_sync_log" name="Sync Logs" parent="menu_pos_sync_root" action="action_pos_sync_log" sequence="30" groups="base.group_user"/>
+</odoo>

--- a/addons/pos_order_sync/views/pos_sync_instance_views.xml
+++ b/addons/pos_order_sync/views/pos_sync_instance_views.xml
@@ -1,0 +1,37 @@
+<odoo>
+    <record id="view_pos_sync_instance_tree" model="ir.ui.view">
+        <field name="name">pos.sync.instance.tree</field>
+        <field name="model">pos.sync.instance</field>
+        <field name="arch" type="xml">
+            <tree>
+                <field name="name"/>
+                <field name="url"/>
+                <field name="db"/>
+            </tree>
+        </field>
+    </record>
+
+    <record id="view_pos_sync_instance_form" model="ir.ui.view">
+        <field name="name">pos.sync.instance.form</field>
+        <field name="model">pos.sync.instance</field>
+        <field name="arch" type="xml">
+            <form>
+                <sheet>
+                    <group>
+                        <field name="name"/>
+                        <field name="url"/>
+                        <field name="db"/>
+                        <field name="username"/>
+                        <field name="password" password="True"/>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="action_pos_sync_instance" model="ir.actions.act_window">
+        <field name="name">Sync Instances</field>
+        <field name="res_model">pos.sync.instance</field>
+        <field name="view_mode">tree,form</field>
+    </record>
+</odoo>

--- a/addons/pos_order_sync/views/pos_sync_log_views.xml
+++ b/addons/pos_order_sync/views/pos_sync_log_views.xml
@@ -1,0 +1,20 @@
+<odoo>
+    <record id="view_pos_sync_log_tree" model="ir.ui.view">
+        <field name="name">pos.sync.log.tree</field>
+        <field name="model">pos.sync.log</field>
+        <field name="arch" type="xml">
+            <tree>
+                <field name="create_date"/>
+                <field name="source_order"/>
+                <field name="status"/>
+                <field name="message"/>
+            </tree>
+        </field>
+    </record>
+
+    <record id="action_pos_sync_log" model="ir.actions.act_window">
+        <field name="name">Sync Logs</field>
+        <field name="res_model">pos.sync.log</field>
+        <field name="view_mode">tree</field>
+    </record>
+</odoo>

--- a/addons/pos_order_sync/wizards/__init__.py
+++ b/addons/pos_order_sync/wizards/__init__.py
@@ -1,0 +1,1 @@
+from . import pos_sync_wizard

--- a/addons/pos_order_sync/wizards/pos_sync_wizard.py
+++ b/addons/pos_order_sync/wizards/pos_sync_wizard.py
@@ -1,0 +1,62 @@
+import json
+import logging
+import requests
+
+from odoo import models, fields
+
+_logger = logging.getLogger(__name__)
+
+
+class PosSyncWizard(models.TransientModel):
+    _name = 'pos.sync.wizard'
+    _description = 'POS Order Sync Wizard'
+
+    source_instance_id = fields.Many2one('pos.sync.instance', required=True)
+    dest_instance_id = fields.Many2one('pos.sync.instance', required=True)
+    start_date = fields.Date(required=True)
+    end_date = fields.Date(required=True)
+
+    def _json_rpc(self, instance, model, method, *args, **kwargs):
+        url = f"{instance.url}/jsonrpc"
+        payload = {
+            'jsonrpc': '2.0',
+            'method': 'call',
+            'params': {
+                'service': 'object',
+                'method': 'execute_kw',
+                'args': [instance.db, self._uid, instance.password, model, method, args, kwargs],
+            },
+            'id': 0,
+        }
+        response = requests.post(url, json=payload)
+        response.raise_for_status()
+        res = response.json()
+        return res.get('result')
+
+    def action_sync(self):
+        self.ensure_one()
+        domain = [
+            ('date_order', '>=', self.start_date),
+            ('date_order', '<=', self.end_date),
+        ]
+        orders = self._json_rpc(self.source_instance_id, 'pos.order', 'search_read', domain, ['name', 'partner_id', 'amount_total'])
+        for order in orders:
+            try:
+                vals = {
+                    'name': order['name'],
+                    'partner_id': order['partner_id'] and order['partner_id'][0] or False,
+                    'amount_total': order['amount_total'],
+                }
+                self._json_rpc(self.dest_instance_id, 'pos.order', 'create', vals)
+                self.env['pos.sync.log'].create({
+                    'source_order': order['name'],
+                    'status': 'success',
+                    'message': 'Created successfully',
+                })
+            except Exception as exc:
+                _logger.exception('Failed to sync order %s', order['name'])
+                self.env['pos.sync.log'].create({
+                    'source_order': order['name'],
+                    'status': 'error',
+                    'message': str(exc),
+                })

--- a/addons/pos_order_sync/wizards/pos_sync_wizard_views.xml
+++ b/addons/pos_order_sync/wizards/pos_sync_wizard_views.xml
@@ -1,0 +1,27 @@
+<odoo>
+    <record id="view_pos_sync_wizard" model="ir.ui.view">
+        <field name="name">pos.sync.wizard.form</field>
+        <field name="model">pos.sync.wizard</field>
+        <field name="arch" type="xml">
+            <form string="Sync POS Orders">
+                <group>
+                    <field name="source_instance_id"/>
+                    <field name="dest_instance_id"/>
+                    <field name="start_date"/>
+                    <field name="end_date"/>
+                </group>
+                <footer>
+                    <button string="Sync" type="object" name="action_sync" class="btn-primary"/>
+                    <button string="Cancel" class="btn-secondary" special="cancel"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+
+    <record id="action_pos_sync_wizard" model="ir.actions.act_window">
+        <field name="name">Sync POS Orders</field>
+        <field name="res_model">pos.sync.wizard</field>
+        <field name="view_mode">form</field>
+        <field name="target">new</field>
+    </record>
+</odoo>


### PR DESCRIPTION
## Summary
- add POS order sync instances, wizard, and logs
- allow syncing POS orders between Odoo 18 instances via JSON-RPC

## Testing
- `python -B -m py_compile addons/pos_order_sync/**/*.py`

------
https://chatgpt.com/codex/tasks/task_b_68c76a575580833188671203fffa540e