### PR TITLE
pos_order_sync: replace tree list view tag with list

### DIFF
--- a/addons/pos_order_sync/views/pos_sync_instance_views.xml
+++ b/addons/pos_order_sync/views/pos_sync_instance_views.xml
@@ -3,11 +3,11 @@
         <field name="name">pos.sync.instance.tree</field>
         <field name="model">pos.sync.instance</field>
         <field name="arch" type="xml">
-            <tree>
+            <list>
                 <field name="name"/>
                 <field name="url"/>
                 <field name="db"/>
-            </tree>
+            </list>
         </field>
     </record>
 
@@ -32,6 +32,6 @@
     <record id="action_pos_sync_instance" model="ir.actions.act_window">
         <field name="name">Sync Instances</field>
         <field name="res_model">pos.sync.instance</field>
-        <field name="view_mode">tree,form</field>
+        <field name="view_mode">list,form</field>
     </record>
 </odoo>

--- a/addons/pos_order_sync/views/pos_sync_log_views.xml
+++ b/addons/pos_order_sync/views/pos_sync_log_views.xml
@@ -3,18 +3,18 @@
         <field name="name">pos.sync.log.tree</field>
         <field name="model">pos.sync.log</field>
         <field name="arch" type="xml">
-            <tree>
+            <list>
                 <field name="create_date"/>
                 <field name="source_order"/>
                 <field name="status"/>
                 <field name="message"/>
-            </tree>
+            </list>
         </field>
     </record>
 
     <record id="action_pos_sync_log" model="ir.actions.act_window">
         <field name="name">Sync Logs</field>
         <field name="res_model">pos.sync.log</field>
-        <field name="view_mode">tree</field>
+        <field name="view_mode">list</field>
     </record>
 </odoo>


### PR DESCRIPTION
## Summary
- replace deprecated `<tree>` tags with `<list>` in pos_order_sync views
- update actions to use `list` view mode

## Testing
- `python -m compileall addons/pos_order_sync`
- `rg "<tree" -n addons/pos_order_sync`


------
https://chatgpt.com/codex/tasks/task_b_68c778b832c08331bef4c22197ea2b39