### PR TITLE
[ADD] us_assistant: port module to Odoo 18

### DIFF
--- a/addons/us_assistant/__manifest__.py
+++ b/addons/us_assistant/__manifest__.py
@@ -3,7 +3,7 @@
     "summary": """Assistant ChatGPT integration powered by UnitSoft""",
     "category": "Discuss",
     "images": ["static/description/banner.png"],
-    "version": "17.0.2.1.0",
+    "version": "18.0.1.0.0",
     "author": "UnitSoft",
     "support": "",
     "website": "https://unitsoft.com.ua/",
@@ -11,7 +11,7 @@
     "price": 50,
     "currency": "EUR",
     "depends": ["base_automation", "base", "crm", "im_livechat"],
-    "external_dependencies": {"python": ["openai"] ,"bin": []},
+    "external_dependencies": {"python": ["openai"], "bin": []},
     "data": [
         "security/us_assistant_groups.xml",
         "security/ir.model.access.csv",

--- a/addons/us_assistant/controllers/discuss_channel_assistant.py
+++ b/addons/us_assistant/controllers/discuss_channel_assistant.py
@@ -1,5 +1,3 @@
-import time
-
 from odoo import http, _
 from odoo.http import request
 from werkzeug.exceptions import NotFound

--- a/addons/us_assistant/models/discuss_channel.py
+++ b/addons/us_assistant/models/discuss_channel.py
@@ -14,19 +14,21 @@ class Channel(models.Model):
             res = channel.channel_member_ids.filtered(lambda channel_member: channel_member.partner_id.is_assistant == True)
             channel.is_assistant_active = True if len(res) > 0 else False
 
-    def _channel_info(self):
-        channel_infos = super()._channel_info()
-        channel_infos_dict = dict((c['id'], c) for c in channel_infos)
-        for channel in self:
-            channel_sudo = channel.sudo()
-            if channel_sudo.channel_type == "livechat" and channel_sudo.livechat_channel_id and channel_sudo.livechat_channel_id.is_only_hint_available == True:
-                channel_sudo.assistant_toggle_status = False
-                assistant_chatbot = self.env.ref("us_assistant.chatbot_script_assistant_bot")
-                member_partner_ids = list(map(lambda x: x.partner_id.id, channel_sudo.channel_member_ids))
-                if assistant_chatbot and assistant_chatbot.sudo().operator_partner_id.id in member_partner_ids:
-                    channel_sudo.assistant_toggle_status = True
-            channel_infos_dict[channel_sudo.id]['assistant_toggle_status'] = channel_sudo.assistant_toggle_status
-        return list(channel_infos_dict.values())
+    def _channel_basic_info(self):
+        info = super()._channel_basic_info()
+        channel_sudo = self.sudo()
+        if (
+            channel_sudo.channel_type == "livechat"
+            and channel_sudo.livechat_channel_id
+            and channel_sudo.livechat_channel_id.is_only_hint_available
+        ):
+            channel_sudo.assistant_toggle_status = False
+            assistant_chatbot = self.env.ref("us_assistant.chatbot_script_assistant_bot", raise_if_not_found=False)
+            member_partner_ids = channel_sudo.channel_member_ids.mapped("partner_id.id")
+            if assistant_chatbot and assistant_chatbot.sudo().operator_partner_id.id in member_partner_ids:
+                channel_sudo.assistant_toggle_status = True
+        info["assistant_toggle_status"] = channel_sudo.assistant_toggle_status
+        return info
 
     def send_message_from_assistant(self, message_text, author_id=None):
         guest = self.env['mail.guest']._get_guest_from_context()

--- a/addons/us_assistant/models/discuss_channel_member.py
+++ b/addons/us_assistant/models/discuss_channel_member.py
@@ -4,8 +4,14 @@ from odoo import models
 class ChannelMember(models.Model):
     _inherit = 'discuss.channel.member'
 
-    def _get_partner_data(self, fields=None):
-        data = super()._get_partner_data(fields=fields)
-        if self.channel_id.channel_type == 'livechat':
-            data['is_assistant'] = self.partner_id.is_assistant
-        return data
+    def _get_store_partner_fields(self, fields):
+        fields = super()._get_store_partner_fields(fields)
+        if fields is None:
+            return fields
+        if isinstance(fields, list):
+            return fields if "is_assistant" in fields else [*fields, "is_assistant"]
+        if isinstance(fields, dict):
+            fields = fields.copy()
+            fields.setdefault("is_assistant", True)
+            return fields
+        return fields

--- a/addons/us_assistant/models/res_partner.py
+++ b/addons/us_assistant/models/res_partner.py
@@ -1,4 +1,4 @@
-from odoo import api, models, fields
+from odoo import models, fields
 from odoo.exceptions import ValidationError
 from odoo.tools.translate import _
 
@@ -9,17 +9,10 @@ class ResPartner(models.Model):
     is_assistant = fields.Boolean(string='Assistant indicator', default=False)
     assistant_id = fields.Many2one("gpt.assistant", string='Assistant')
 
-    def mail_partner_format(self, fields=None):
-        partners_format = super().mail_partner_format(fields=fields)
-
-        if not fields:
-            fields = {'is_assistant': True}
+    def _to_store(self, store, /, *, fields=None, main_user_by_partner=None):
+        super()._to_store(store, fields=fields, main_user_by_partner=main_user_by_partner)
         for partner in self:
-            if 'is_assistant' in fields:
-                partners_format.get(partner).update({
-                    'is_assistant': partner.is_assistant
-                })
-        return partners_format
+            store.add(partner, {"is_assistant": partner.is_assistant})
 
     def unlink(self):
         for record in self:

--- a/addons/us_assistant/static/src/core/common/message_model_patch.js
+++ b/addons/us_assistant/static/src/core/common/message_model_patch.js
@@ -2,19 +2,20 @@
 
 import { Message } from "@mail/core/common/message";
 
-import { useState } from "@odoo/owl";
 import { patch } from "@web/core/utils/patch";
-import { convertBrToLineBreak, htmlToTextContentInline } from "@mail/utils/common/format";
+import { convertBrToLineBreak } from "@mail/utils/common/format";
+import { toRaw } from "@odoo/owl";
 
 patch(Message.prototype, {
     onClickAssistantEdit() {
-        return this.enterAssisstantEditMode();
+        return this.enterAssistantEditMode();
     },
-    enterAssisstantEditMode() {
-        const messageContent = convertBrToLineBreak(this.props.message.body);
-        this.props.message.composer = {
-            mentionedPartners: this.props.message.recipients,
-            textInputContent: messageContent,
+    enterAssistantEditMode() {
+        const message = toRaw(this.props.message);
+        const messageContent = convertBrToLineBreak(message.body);
+        message.composer = {
+            mentionedPartners: message.recipients,
+            text: messageContent,
             isAssistantEditing: true,
             selection: {
                 start: messageContent.length,
@@ -25,6 +26,8 @@ patch(Message.prototype, {
         this.state.isEditing = true;
     },
     get canAssistantHint() {
-        return Boolean(!this.message.is_transient && this.message.res_id && this.message.type === "comment");
+        return Boolean(
+            !this.message.is_transient && this.message.res_id && this.message.type === "comment"
+        );
     }
 });

--- a/addons/us_assistant/static/src/core/common/persona_model_patch.js
+++ b/addons/us_assistant/static/src/core/common/persona_model_patch.js
@@ -5,8 +5,5 @@ import { Record } from "@mail/core/common/record";
 import { patch } from "@web/core/utils/patch";
 
 patch(Persona.prototype, {
-    setup() {
-        super.setup();
-        this.is_assistant = false;
-    }
+    is_assistant: Record.attr(false),
 });

--- a/addons/us_assistant/static/src/core/common/thread_model_patch.js
+++ b/addons/us_assistant/static/src/core/common/thread_model_patch.js
@@ -8,11 +8,11 @@ import { Record } from "@mail/core/common/record";
 
 patch(Thread.prototype, {
     setup() {
-         super.setup();
-         this.assistantMembers = Record.many("ChannelMember", {
+        super.setup(...arguments);
+        this.assistantMembers = Record.many("ChannelMember", {
             compute() {
-                return this.channelMembers.filter((m) => m?.persona?.is_assistant === true);
-            }
+                return this.channelMembers.filter((member) => member?.persona?.is_assistant === true);
+            },
         });
     },
     update(data) {
@@ -20,6 +20,8 @@ patch(Thread.prototype, {
         assignDefined(this, data, ["assistant_toggle_status"]);
     },
     get correspondents() {
-        return super.correspondents.filter((correspondent) => !correspondent.is_assistant);
+        return super.correspondents.filter(
+            (correspondent) => !correspondent.persona?.is_assistant
+        );
     },
 });

--- a/addons/us_assistant/static/src/core/common/thread_service.js
+++ b/addons/us_assistant/static/src/core/common/thread_service.js
@@ -1,48 +1,64 @@
 /** @odoo-module */
 
-import { _t } from "@web/core/l10n/translation";
-import { ThreadService } from "@mail/core/common/thread_service";
+import { Thread } from "@mail/core/common/thread_model";
 import { patch } from "@web/core/utils/patch";
 
-patch(ThreadService.prototype, {
-    async post(
-        thread,
-        body,
-        {
-            attachments = [],
-            isNote = false,
-            parentId,
-            mentionedChannels = [],
-            mentionedPartners = [],
-            cannedResponseIds,
-        } = {}
-    ) {
-        const message = await super.post(thread, body, {attachments,isNote,parentId,mentionedChannels,mentionedPartners,cannedResponseIds});
-        if (thread.assistant_toggle_status === true) {
-            thread.messages.sort((m1, m2) => m1.id - m2.id);
+patch(Thread.prototype, {
+    async post(body, postData = {}, extraData = {}) {
+        const assistantPostData = {
+            attachments: postData.attachments ? [...postData.attachments] : [],
+            cannedResponseIds: postData.cannedResponseIds,
+            emailAddSignature: postData.emailAddSignature,
+            isNote: postData.isNote,
+            mentionedChannels: postData.mentionedChannels ? [...postData.mentionedChannels] : [],
+            mentionedPartners: postData.mentionedPartners ? [...postData.mentionedPartners] : [],
+        };
+        const message = await super.post(body, postData, extraData);
+        if (!message) {
+            return message;
         }
-        if (thread.composer){thread.composer.textInputContent = "";}
-        let result_typing = false;
-        if (thread.model == "discuss.channel") {
-          result_typing = await this.rpc("/mail/typing_status", { channel_id: message.res_id, is_typing: true });
+        if (this.assistant_toggle_status === true) {
+            this.messages.sort((m1, m2) => m1.id - m2.id);
         }
-        if (message && result_typing && thread.model == "discuss.channel") {
-            const params = await this.getMessagePostParams({
-                attachments,
-                body,
-                cannedResponseIds,
-                isNote,
-                mentionedChannels,
-                mentionedPartners,
-                thread,
+        if (this.composer && !this.composer.message) {
+            this.composer.text = "";
+        }
+        if (this.model !== "discuss.channel") {
+            return message;
+        }
+        const rpc = this.store.env.services.rpc;
+        let typingResult = false;
+        try {
+            typingResult = await rpc("/mail/typing_status", {
+                channel_id: message.res_id,
+                is_typing: true,
             });
-            Object.assign(params, {thread_id:message.res_id});
+        } catch (err) {
+            console.error(err);
+        }
+        if (typingResult) {
+            const params = await this.store.getMessagePostParams({
+                body,
+                postData: assistantPostData,
+                thread: this,
+            });
+            Object.assign(params, extraData, { thread_id: message.res_id });
             try {
-                await this.rpc("/mail/assistant_message_post", { message_text: body, params:params });
-            } catch (_err) {
-                console.log(_err);
+                await rpc("/mail/assistant_message_post", {
+                    message_text: body,
+                    params,
+                });
+            } catch (err) {
+                console.error(err);
             } finally {
-                await this.rpc("/mail/typing_status", { channel_id: message.res_id, is_typing: false });
+                try {
+                    await rpc("/mail/typing_status", {
+                        channel_id: message.res_id,
+                        is_typing: false,
+                    });
+                } catch (err) {
+                    console.error(err);
+                }
             }
         }
         return message;

--- a/addons/us_assistant/static/src/core/web/composer_patch.js
+++ b/addons/us_assistant/static/src/core/web/composer_patch.js
@@ -4,36 +4,45 @@ import { Composer } from "@mail/core/common/composer";
 
 import { _t } from "@web/core/l10n/translation";
 import { patch } from "@web/core/utils/patch";
+import { useService } from "@web/core/utils/hooks";
 
 patch(Composer.prototype, {
     setup() {
-        super.setup();
-        this.isAssisatantEditing = false;
+        super.setup(...arguments);
+        this.rpcService = useService("rpc");
     },
     get HINT_TEXT() {
         return _t("Hint");
     },
     async rpcAssistantHint() {
-        const res = await this.rpc("/mail/channel_assistant_hint",{
-            message_id: this.message.id,
-            hint: this.props.composer.textInputContent,
+        const composer = this.props.composer;
+        if (!composer?.message) {
+            return;
+        }
+        const res = await this.rpcService("/mail/channel_assistant_hint", {
+            message_id: composer.message.id,
+            hint: composer.text,
         });
         if (!res.success) {
-            this.env.services.notification.add(res.error,{
-                type: 'warning',
+            this.env.services.notification.add(res.error, {
+                type: "warning",
             });
             return;
         }
-        this.props.composer.message.originThread.composer.textInputContent = res.hint;
+        composer.text = res.hint;
+        composer.selection = {
+            start: res.hint.length,
+            end: res.hint.length,
+            direction: "none",
+        };
         if (this.props.onPostCallback) {
             this.props.onPostCallback();
         }
     },
     async editMessage() {
-        if (this.props.composer.isAssistantEditing === true) {
+        if (this.props.composer.isAssistantEditing) {
             await this.rpcAssistantHint();
-        }
-        else {
+        } else {
             await super.editMessage();
         }
     },

--- a/addons/us_assistant/static/src/core/web/message_actions.js
+++ b/addons/us_assistant/static/src/core/web/message_actions.js
@@ -2,7 +2,6 @@
 
 import { messageActionsRegistry } from "@mail/core/common/message_actions";
 import { _t } from "@web/core/l10n/translation";
-import { useComponent, useState } from "@odoo/owl";
 
 messageActionsRegistry
     .add("assistant-hint", {

--- a/addons/us_assistant/static/src/core/web/thread_actions.js
+++ b/addons/us_assistant/static/src/core/web/thread_actions.js
@@ -17,7 +17,7 @@ threadActionsRegistry
         icon: "fa fa-fw fa-lightbulb-o",
         iconLarge: "fa fa-fw fa-lg fa-lightbulb-o",
         name: _t("Assistant"),
-        nameActive: _t("Asssistant"),
+        nameActive: _t("Assistant"),
         sequence: 1,
         toggle: true,
     });

--- a/addons/us_assistant/static/src/discuss/core/common/assistant_panel.js
+++ b/addons/us_assistant/static/src/discuss/core/common/assistant_panel.js
@@ -1,13 +1,10 @@
 /* @odoo-module */
 
-import { DateSection } from "@mail/core/common/date_section";
 import { ActionPanel } from "@mail/discuss/core/common/action_panel";
-import { AttachmentList } from "@mail/core/common/attachment_list";
 import { _t } from "@web/core/l10n/translation";
 
-import { Component, onWillStart, onWillUpdateProps } from "@odoo/owl";
+import { Component, onWillStart, onWillUpdateProps, useState } from "@odoo/owl";
 import { useService } from "@web/core/utils/hooks";
-import { useSequential, useVisible } from "@mail/utils/common/hooks";
 
 /**
  * @typedef {Object} Props
@@ -19,16 +16,16 @@ export class AssistantPanel extends Component {
     static template = "us_assistant.AssistantPanel";
 
     setup() {
-        this.store = useService("mail.store");
+        this.store = useState(useService("mail.store"));
         this.rpc = useService("rpc");
-        this.channelMemberService = useService("discuss.channel.member");
-        this.threadService = useService("mail.thread");
         onWillStart(() => {
-            this.threadService.fetchChannelMembers(this.props.thread);
+            if (this.props.thread.fetchMembersState === "not_fetched") {
+                this.props.thread.fetchChannelMembers();
+            }
         });
         onWillUpdateProps((nextProps) => {
-            if (nextProps.thread.notEq(this.props.thread)) {
-                this.threadService.fetchChannelMembers(nextProps.thread);
+            if (nextProps.thread.fetchMembersState === "not_fetched") {
+                nextProps.thread.fetchChannelMembers();
             }
         });
     }
@@ -44,7 +41,7 @@ export class AssistantPanel extends Component {
         if (member.persona?.eq(this.store.self)) {
             return false;
         }
-        if (member.persona.type === "guest") {
+        if (member.persona?.type === "guest") {
             return false;
         }
         return true;
@@ -54,7 +51,7 @@ export class AssistantPanel extends Component {
         if (!this.canOpenChatWith(member)) {
             return;
         }
-        this.threadService.openChat({ partnerId: member.persona.id });
+        this.store.openChat({ partnerId: member.persona.id });
     }
 
     async onChangeUseAssistant(ev) {
@@ -63,8 +60,8 @@ export class AssistantPanel extends Component {
             channel_toggle: !this.props.thread.assistant_toggle_status,
         });
         if (res.error) {
-            this.env.services.notification.add(_t(res.error),{
-                type: 'warning',
+            this.env.services.notification.add(_t(res.error), {
+                type: "warning",
             });
             if (ev.target.checked) {
                 ev.target.checked = false;
@@ -72,6 +69,5 @@ export class AssistantPanel extends Component {
         } else {
             this.props.thread.assistant_toggle_status = !this.props.thread.assistant_toggle_status;
         }
-
     }
 }

--- a/addons/us_assistant/static/src/discuss/core/common/assistant_panel.xml
+++ b/addons/us_assistant/static/src/discuss/core/common/assistant_panel.xml
@@ -30,9 +30,9 @@
         <div class="o-discuss-ChannelMember d-flex align-items-center p-2 bg-view" t-att-class="{ 'cursor-pointer': canOpenChatWith(member) }" t-on-click.stop="() => this.openChatAvatar(member)">
             <div class="bg-inherit o-discuss-ChannelMember-avatar position-relative d-flex ms-4 flex-shrink-0">
                 <img class="w-100 h-100 rounded o_object_fit_cover"
-                     t-att-src="threadService.avatarUrl(member.persona, props.thread)"/>
+                     t-att-src="member.persona.avatarUrl"/>
             </div>
-            <span t-ref="displayName" class="ms-2 text-truncate" t-esc="channelMemberService.getName(member)"/>
+            <span t-ref="displayName" class="ms-2 text-truncate" t-esc="member.name"/>
 
         </div>
     </t>

--- a/addons/us_assistant/wizard/vector_store_wizard.py
+++ b/addons/us_assistant/wizard/vector_store_wizard.py
@@ -35,7 +35,7 @@ class VectorStoreWizard(models.TransientModel):
             'tag': 'display_notification',
             'params': {
                 'type': 'success',
-                'message': _('File uploaded successfully'),
+                'message': _('Vector store linked successfully'),
                 'next': {'type': 'ir.actions.act_window_close'},
             }
         }


### PR DESCRIPTION
## Summary
- bump the us_assistant manifest to 18.0 and migrate partner/channel helpers to the new store API
- rework discuss channel assistant toggling and frontend patches to match the Odoo 18 thread/composer architecture
- update vector store wizard messaging while keeping assistant UI features intact

## Testing
- python3 -m compileall odoo/addons/us_assistant

------
https://chatgpt.com/codex/tasks/task_b_68dc7825b85c83319dc9b80eb36e5042