### PR TITLE
Switch us_assistant tree views to list

### DIFF
--- a/addons/us_assistant/views/gpt_assistant_views.xml
+++ b/addons/us_assistant/views/gpt_assistant_views.xml
@@ -3,18 +3,18 @@
     <record id="gpt_assistant_action" model="ir.actions.act_window">
         <field name="name">Assistants</field>
         <field name="res_model">gpt.assistant</field>
-        <field name="view_mode">tree,form</field>
+        <field name="view_mode">list,form</field>
     </record>
 
     <record id="gpt_assistant_view_tree" model="ir.ui.view">
         <field name="name">gpt.assistant.tree</field>
         <field name="model">gpt.assistant</field>
         <field name="arch" type="xml">
-            <tree>
+            <list>
                  <field name="name"/>
                 <field name="assistant_id"/>
                 <field name="vector_store_id"/>
-            </tree>
+            </list>
         </field>
     </record>
 

--- a/addons/us_assistant/views/vector_store_views.xml
+++ b/addons/us_assistant/views/vector_store_views.xml
@@ -3,17 +3,17 @@
     <record id="vector_store_action" model="ir.actions.act_window">
         <field name="name">Vector Store</field>
         <field name="res_model">vector.store</field>
-        <field name="view_mode">tree,form</field>
+        <field name="view_mode">list,form</field>
     </record>
 
     <record id="vector_store_tree" model="ir.ui.view">
         <field name="name">vector.store.tree</field>
         <field name="model">vector.store</field>
         <field name="arch" type="xml">
-            <tree>
+            <list>
                 <field name="name"/>
                 <field name="store_id"/>
-            </tree>
+            </list>
         </field>
     </record>
 


### PR DESCRIPTION
## Summary
- replace deprecated `<tree>` views with `<list>` in the us_assistant module
- update the related window actions to use the list view mode

## Testing
- ./odoo-bin -d test_us_assistant --addons-path=addons -i us_assistant --stop-after-init *(fails: missing python dependency `babel` in the environment)*

------
https://chatgpt.com/codex/tasks/task_b_68dc7e45bf48833190329d4b6670b64c