### PR TITLE
[ADD] cf_inventory_count_sheet module

### DIFF
--- a/addons/cf_inventory_count_sheet/__init__.py
+++ b/addons/cf_inventory_count_sheet/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/addons/cf_inventory_count_sheet/__manifest__.py
+++ b/addons/cf_inventory_count_sheet/__manifest__.py
@@ -1,0 +1,20 @@
+# Copyright (C) 2024 Code Factory
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+{
+    "name": "CF Inventory Count Sheet",
+    "summary": "Print inventory count sheet from stock adjustments",
+    "version": "18.0.1.0.0",
+    "license": "AGPL-3",
+    "author": "Code Factory",
+    "website": "https://www.codefactory.cr/",
+    "depends": ["stock", "stock_inventory"],
+    "category": "Inventory/Inventory",
+    "data": [
+        "report/inventory_count_sheet_report.xml",
+        "report/inventory_count_sheet_templates.xml",
+        "views/stock_inventory_views.xml",
+    ],
+    "installable": True,
+    "application": False,
+}

--- a/addons/cf_inventory_count_sheet/models/__init__.py
+++ b/addons/cf_inventory_count_sheet/models/__init__.py
@@ -1,0 +1,1 @@
+from . import stock_inventory

--- a/addons/cf_inventory_count_sheet/models/stock_inventory.py
+++ b/addons/cf_inventory_count_sheet/models/stock_inventory.py
@@ -1,0 +1,14 @@
+# Copyright (C) 2024 Code Factory
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class StockInventory(models.Model):
+    _inherit = "stock.inventory"
+
+    def action_print_count_sheet(self):
+        self.ensure_one()
+        return self.env.ref(
+            "cf_inventory_count_sheet.action_report_inventory_count_sheet"
+        ).report_action(self)

--- a/addons/cf_inventory_count_sheet/report/inventory_count_sheet_report.xml
+++ b/addons/cf_inventory_count_sheet/report/inventory_count_sheet_report.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <report
+        id="action_report_inventory_count_sheet"
+        model="stock.inventory"
+        string="Hoja de recuento de inventario"
+        report_type="qweb-pdf"
+        name="cf_inventory_count_sheet.report_inventory_count_sheet"
+        paperformat="paperformat_euro"
+        print_report_name="('Hoja de recuento - %s' % (object.name or ''))"
+    />
+</odoo>

--- a/addons/cf_inventory_count_sheet/report/inventory_count_sheet_templates.xml
+++ b/addons/cf_inventory_count_sheet/report/inventory_count_sheet_templates.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <template id="report_inventory_count_sheet">
+        <t t-call="web.html_container">
+            <t t-foreach="docs" t-as="o">
+                <t t-call="web.external_layout">
+                    <div class="page">
+                        <t t-set="company" t-value="o.company_id"/>
+                        <div class="mb-4">
+                            <div class="row">
+                                <div class="col-8">
+                                    <h3 class="o_report_title mb-1" t-esc="company.name"/>
+                                    <p class="mb-0" t-esc="company.partner_id.contact_address"/>
+                                </div>
+                                <div class="col-4 text-end">
+                                    <div>
+                                        <strong>Fecha contable:</strong>
+                                        <span t-esc="o.date and format_datetime(o.date) or ''"/>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <h2 class="text-center mb-3">
+                            Inventario <span t-esc="o.name"/>
+                        </h2>
+                        <t t-if="o.location_ids">
+                            <p class="mb-3">
+                                <strong>Ubicaciones:</strong>
+                                <span t-esc="', '.join(o.location_ids.mapped('complete_name'))"/>
+                            </p>
+                        </t>
+                        <t t-if="o.stock_quant_ids">
+                            <table class="table table-sm table-bordered o_main_table">
+                                <thead class="table-light">
+                                    <tr>
+                                        <th class="text-center" style="width:4%">#</th>
+                                        <th>Ubicación</th>
+                                        <th>Referencia</th>
+                                        <th>Producto</th>
+                                        <th>Lote / Serie</th>
+                                        <th class="text-end">Cantidad teórica</th>
+                                        <th class="text-center">UdM</th>
+                                        <th class="text-end">Cantidad contada</th>
+                                        <th class="text-end">Diferencia</th>
+                                        <th>Firma</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <t t-foreach="o.stock_quant_ids" t-as="quant">
+                                        <tr>
+                                            <td class="text-center" t-esc="loop.index"/>
+                                            <td t-esc="quant.location_id.display_name"/>
+                                            <td t-esc="quant.product_id.default_code or ''"/>
+                                            <td t-esc="quant.product_id.display_name"/>
+                                            <td t-esc="quant.lot_id.name or ''"/>
+                                            <td class="text-end">
+                                                <span t-esc="formatLang(quant.quantity)"/>
+                                            </td>
+                                            <td class="text-center" t-esc="(quant.product_uom_id or quant.product_id.uom_id).name"/>
+                                            <td class="text-end">
+                                                <span t-esc="formatLang(quant.inventory_quantity)"/>
+                                            </td>
+                                            <td class="text-end">
+                                                <span t-esc="formatLang(quant.inventory_diff_quantity)"/>
+                                            </td>
+                                            <td></td>
+                                        </tr>
+                                    </t>
+                                </tbody>
+                            </table>
+                        </t>
+                        <t t-else="">
+                            <p class="text-center text-muted">
+                                No hay productos pendientes de contar para este ajuste.
+                            </p>
+                        </t>
+                    </div>
+                </t>
+            </t>
+        </t>
+    </template>
+</odoo>

--- a/addons/cf_inventory_count_sheet/views/stock_inventory_views.xml
+++ b/addons/cf_inventory_count_sheet/views/stock_inventory_views.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="view_inventory_group_form" model="ir.ui.view">
+        <field name="name">stock.inventory.form.view.cf.count.sheet</field>
+        <field name="model">stock.inventory</field>
+        <field name="inherit_id" ref="stock_inventory.view_inventory_group_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//form/header" position="inside">
+                <button
+                    type="object"
+                    name="action_print_count_sheet"
+                    string="Imprimir hoja de recuento"
+                    class="btn-secondary"
+                />
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
## Summary
- add CF Inventory Count Sheet module metadata and initialization files
- extend stock inventory form with a print button invoking a new PDF report
- implement QWeb template and report action for the inventory count sheet layout

## Testing
- python3 -m compileall addons/cf_inventory_count_sheet

------
https://chatgpt.com/codex/tasks/task_b_68e0ad4871688331b2c33e5182472231