### PR TITLE
Handle missing accounting date in inventory count report

### DIFF
--- a/addons/cf_inventory_count_sheet/report/inventory_count_sheet_templates.xml
+++ b/addons/cf_inventory_count_sheet/report/inventory_count_sheet_templates.xml
@@ -14,8 +14,9 @@
                                 </div>
                                 <div class="col-4 text-end">
                                     <div>
+                                        <t t-set="count_date" t-value="getattr(o, 'accounting_date', False) or o.date or fields.Date.context_today(o)"/>
                                         <strong>Fecha contable:</strong>
-                                        <span t-esc="o.date and format_datetime(o.date) or ''"/>
+                                        <span t-esc="format_datetime(count_date)"/>
                                     </div>
                                 </div>
                             </div>


### PR DESCRIPTION
## Summary
- ensure the inventory count sheet report computes a count date from the accounting date, scheduled date, or today
- render the computed date with `format_datetime` so the report remains valid when the accounting date is missing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e0b12fca248331ad72c33e09b16021