### PR TITLE
Fix paper format reference for inventory count sheet report

### DIFF
--- a/addons/cf_inventory_count_sheet/report/inventory_count_sheet_report.xml
+++ b/addons/cf_inventory_count_sheet/report/inventory_count_sheet_report.xml
@@ -6,7 +6,7 @@
         <field name="report_type">qweb-pdf</field>
         <field name="report_name">cf_inventory_count_sheet.report_inventory_count_sheet</field>
         <field name="print_report_name">'Hoja de recuento - %s' % (object.name or '')</field>
-        <field name="paperformat_id" ref="paperformat_euro"/>
+        <field name="paperformat_id" ref="base.paperformat_euro"/>
         <field name="binding_model_id" ref="stock.model_stock_inventory"/>
         <field name="binding_type">report</field>
     </record>


### PR DESCRIPTION
## Summary
- reference the Euro paper format record from base in the inventory count sheet report definition

## Testing
- ./odoo-bin -d test_cf_inventory_count_sheet --addons-path=addons -i cf_inventory_count_sheet --stop-after-init *(fails: ModuleNotFoundError: No module named 'babel')*


------
https://chatgpt.com/codex/tasks/task_b_68e0b5ef0e988331918aa8c72e34792c